### PR TITLE
Add default case to basename selector

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -35,7 +35,7 @@ class nagios::params {
 
   $basename = $::osfamily ? {
     'Debian' => 'nagios3',
-    'RedHat' => 'nagios',
+    default  => 'nagios',
   }
 
   $rootdir     = "/etc/${basename}"


### PR DESCRIPTION
Use default case instead of RedHat for better cross platform support 