### PR TITLE
Use resource_type param to identify nagios resource type

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -192,7 +192,7 @@ class nagios::client (
 
   # We always export a host configuration
   nagios::resource { $::fqdn:
-    type               => 'host',
+    resource_type      => 'host',
     defaultresourcedef => $defaulthostconfig,
     nagiostag          => $nagiostag,
     resourcedef        => $hostconfig,
@@ -200,49 +200,49 @@ class nagios::client (
 
   # create any base services
   create_resources('nagios::resource', $baseservices, {
-    'type'             => 'service',
+    'resource_type'    => 'service',
     defaultresourcedef => $defaultserviceconfig,
     nagiostag          => $nagiostag,
   })
 
   # create any host dependencies
   create_resources('nagios::resource', $hostdependencies, {
-    'type'             => 'hostdependency',
+    'resource_type'    => 'hostdependency',
     defaultresourcedef => $defaulthostdependencies,
     nagiostag          => $nagiostag,
   })
 
   # create any hostextinfo
   create_resources('nagios::resource', $hostextinfo, {
-    'type'             => 'hostextinfo',
+    'resource_type'    => 'hostextinfo',
     defaultresourcedef => $defaulthostextinfo,
     nagiostag          => $nagiostag,
   })
 
   # create host specific services
   create_resources('nagios::resource', $hostservices, {
-    'type'             => 'service',
+    'resource_type'    => 'service',
     defaultresourcedef => $defaultserviceconfig,
     nagiostag          => $nagiostag,
   })
 
   # create service dependencies
   create_resources('nagios::resource', $hostservicedependencies, {
-    'type'             => 'servicedependency',
+    'resource_type'    => 'servicedependency',
     defaultresourcedef => $defaultservicedependencies,
     nagiostag          => $nagiostag,
   })
 
   # create service escalations
   create_resources('nagios::resource', $hostserviceescalation, {
-    'type'             => 'serviceescalation',
+    'resource_type'    => 'serviceescalation',
     defaultresourcedef => $defaultserviceescalation,
     nagiostag          => $nagiostag,
   })
 
   # create service extinfo
   create_resources('nagios::resource', $hostserviceextinfo, {
-    'type'             => 'serviceextinfo',
+    'resource_type'    => 'serviceextinfo',
     defaultresourcedef => $defaultserviceextinfo,
     nagiostag          => $nagiostag,
   })

--- a/manifests/resource.pp
+++ b/manifests/resource.pp
@@ -1,7 +1,7 @@
 # == Define: nagios::resource
 #
 # Defines a nagios::resource and calls the appropriate
-# nagios::resource::${type} to configure it
+# nagios::resource::${resource_type} to configure it
 #
 # === Parameters
 #
@@ -40,7 +40,7 @@
 #
 # === Variables
 #
-# [*type*]
+# [*resource_type*]
 #   What type of resource is being created
 #   Type: string
 #   This is required
@@ -58,7 +58,7 @@
 # Copyright 2015 Andrew J Grimberg
 #
 define nagios::resource (
-  $type,
+  $resource_type,
   $defaultresourcedef = {},
   $nagiostag          = '',
   $resourcedef        = {},
@@ -73,7 +73,9 @@ define nagios::resource (
 
   # determine what our target filename should be
   $name_down = downcase(regsubst($name, '\s+', '_'))
-  $target = "${nagios::params::resourcedir}/${type}_${::fqdn}_${name_down}.cfg"
+  # lint:ignore:80chars
+  $target = "${nagios::params::resourcedir}/${resource_type}_${::fqdn}_${name_down}.cfg"
+  # lint:endignore
 
   $_nagiostag = $nagiostag ? {
     ''      => undef,
@@ -96,7 +98,7 @@ define nagios::resource (
 
   $_resourcedef = merge($defaultresourcedef, $resourcedef, $mergedef)
 
-  case $type {
+  case $resource_type {
     command: {
       nagios::resource::command { $name:
         resourcedef => $_resourcedef,
@@ -170,7 +172,7 @@ define nagios::resource (
     default: {
       # normally we would do a validate_re but for some reason the regex
       # doesn't want to work correctly
-      fail("Unknown resource type passed of '${type}'")
+      fail("Unknown resource type passed of '${resource_type}'")
     }
   }
 }

--- a/manifests/server/config/export.pp
+++ b/manifests/server/config/export.pp
@@ -55,75 +55,75 @@ class nagios::server::config::export (
 
   # build out needed templates
   create_resources('nagios::resource', $templatecontact, {
-    'type'             => 'contact',
+    'resource_type'    => 'contact',
     defaultresourcedef => {},
     nagiostag          => $nagiostag,
   })
 
   create_resources('nagios::resource', $templatehost, {
-    'type'             => 'host',
+    'resource_type'    => 'host',
     defaultresourcedef => {},
     nagiostag          => $nagiostag,
   })
 
   create_resources('nagios::resource', $templateservice, {
-    'type'             => 'service',
+    'resource_type'    => 'service',
     defaultresourcedef => {},
     nagiostag          => $nagiostag,
   })
 
   create_resources('nagios::resource', $templatetimeperiod, {
-    'type'             => 'timeperiod',
+    'resource_type'    => 'timeperiod',
     defaultresourcedef => {},
     nagiostag          => $nagiostag,
   })
 
   # setup the default commands
   create_resources('nagios::resource', $defaultcommands, {
-    'type'             => 'command',
+    'resource_type'    => 'command',
     defaultresourcedef => {},
     nagiostag          => $nagiostag,
   })
 
   create_resources('nagios::resource', $defaultcontacts, {
-    'type'             => 'contact',
+    'resource_type'    => 'contact',
     defaultresourcedef => {},
     nagiostag          =>  $nagiostag,
   })
 
   create_resources('nagios::resource', $defaultcontactgroups, {
-    'type'             => 'contactgroup',
+    'resource_type'    => 'contactgroup',
     defaultresourcedef => {},
     nagiostag          => $nagiostag,
   })
 
   create_resources('nagios::resource', $defaulthostgroups, {
-    'type'             => 'hostgroup',
+    'resource_type'    => 'hostgroup',
     defaultresourcedef => {},
     nagiostag          => $nagiostag,
   })
 
   # site local commands
   create_resources('nagios::resource', $localcommands, {
-    'type'             => 'command',
+    'resource_type'    => 'command',
     defaultresourcedef => $localcommanddefaults,
     nagiostag          => $nagiostag,
   })
 
   create_resources('nagios::resource', $localcontacts, {
-    'type'             => 'contact',
+    'resource_type'    => 'contact',
     defaultresourcedef => $localcontactdefaults,
     nagiostag          => $nagiostag,
   })
 
   create_resources('nagios::resource', $localcontactgroups, {
-    'type'             => 'contactgroup',
+    'resource_type'    => 'contactgroup',
     defaultresourcedef => $localcontactgroupdefaults,
     nagiostag          => $nagiostag,
   })
 
   create_resources('nagios::resource', $localhostgroups, {
-    'type'             => 'hostgroup',
+    'resource_type'    => 'hostgroup',
     defaultresourcedef => $localhostgroupdefaults,
     nagiostag          => $nagiostag,
   })

--- a/spec/classes/client_spec.rb
+++ b/spec/classes/client_spec.rb
@@ -13,7 +13,7 @@ describe 'nagios::client', :type => :class do
   context 'with defaults for all parameters' do
     it { should contain_class('nagios::client') }
     it { should contain_nagios__resource('test.example.com').with(
-      'type'                 => 'host',
+      'resource_type'                 => 'host',
       'nagiostag'            => '',
       'defaultresourcedef'   => {
         'address'            => '192.168.0.1',
@@ -97,7 +97,7 @@ describe 'nagios::client', :type => :class do
     }
 
     it { should contain_nagios__resource('testservice-test.example.com').with(
-      'type'                  => 'service',
+      'resource_type'          => 'service',
       'nagiostag'             => '',
       'defaultresourcedef'    => {
         'check_interval'      => '5',
@@ -114,7 +114,7 @@ describe 'nagios::client', :type => :class do
     ) }
 
     it { should contain_nagios__resource('dep-test.example.com').with(
-      'type'                  => 'hostdependency',
+      'resource_type'          => 'hostdependency',
       'defaultresourcedef'    => {
         'host_name'           => 'hostdeptest'
       },
@@ -124,7 +124,7 @@ describe 'nagios::client', :type => :class do
     ) }
 
     it { should contain_nagios__resource('ext-test.example.com').with(
-      'type'                => 'hostextinfo',
+      'resource_type'       => 'hostextinfo',
       'defaultresourcedef'  => {
         'host_name'         => 'test.example.com',
       },
@@ -134,7 +134,7 @@ describe 'nagios::client', :type => :class do
     ) }
 
     it { should contain_nagios__resource('testservice2-test.example.com').with(
-      'type'                  => 'service',
+      'resource_type'         => 'service',
       'defaultresourcedef'    => {
         'check_interval'      => '5',
         'ensure'              => 'present',
@@ -150,7 +150,7 @@ describe 'nagios::client', :type => :class do
     ) }
 
     it { should contain_nagios__resource('servicedep1-test.example.com').with(
-      'type'                  => 'servicedependency',
+      'resource_type'         => 'servicedependency',
       'defaultresourcedef'    => {
         'host_name'           => 'test.example.com',
       },
@@ -160,7 +160,7 @@ describe 'nagios::client', :type => :class do
     ) }
 
     it { should contain_nagios__resource('escalation1-test.example.com').with(
-      'type'               => 'serviceescalation',
+      'resource_type'      => 'serviceescalation',
       'defaultresourcedef' => {
         'host_name'        => 'test.example.com',
       },
@@ -170,7 +170,7 @@ describe 'nagios::client', :type => :class do
     ) }
 
     it { should contain_nagios__resource('extinfo1-test.example.com').with(
-      'type'                  => 'serviceextinfo',
+      'resource_type'         => 'serviceextinfo',
       'defaultresourcedef'    => {
         'host_name'           => 'test.example.com',
       },

--- a/spec/classes/server__config__export_spec.rb
+++ b/spec/classes/server__config__export_spec.rb
@@ -104,66 +104,66 @@ describe 'nagios::server::config::export' do
     it { should contain_class('nagios::server::config::export') }
 
     it { should contain_nagios__resource('defaultcommand').with(
-      'type'               => 'command',
+      'resource_type'      => 'command',
       'nagiostag'          => 'test',
       'defaultresourcedef' => {},
       'resourcedef'        => {},
     ) }
 
     it { should contain_nagios__resource('defaultcontact').with(
-      'type' => 'contact',
+      'resource_type' => 'contact',
     ) }
 
     it { should contain_nagios__resource('defaultcontactgroup').with(
-      'type' => 'contactgroup',
+      'resource_type' => 'contactgroup',
     ) }
 
     it { should contain_nagios__resource('defaulthostgroup').with(
-      'type' => 'hostgroup',
+      'resource_type' => 'hostgroup',
     ) }
 
     it { should contain_nagios__resource('localcommand').with(
-      'type'               => 'command',
+      'resource_type'      => 'command',
       'defaultresourcedef' => {
         'use'              => 'defaultcommand',
       },
     ) }
 
     it { should contain_nagios__resource('localcontact').with(
-      'type'               => 'contact',
+      'resource_type'      => 'contact',
       'defaultresourcedef' => {
         'use'              => 'defaultcontact',
       },
     ) }
 
     it { should contain_nagios__resource('localcontactgroup').with(
-      'type'               => 'contactgroup',
+      'resource_type'      => 'contactgroup',
       'defaultresourcedef' => {
         'use'              => 'defaultcontactgroup',
       },
     ) }
 
     it { should contain_nagios__resource('localhostgroup').with(
-      'type'               => 'hostgroup',
+      'resource_type'      => 'hostgroup',
       'defaultresourcedef' => {
         'use'              => 'defaulthostgroup',
       },
     ) }
 
     it { should contain_nagios__resource('templatecontact').with(
-      'type' => 'contact',
+      'resource_type' => 'contact',
     ) }
 
     it { should contain_nagios__resource('templatehost').with(
-      'type' => 'host',
+      'resource_type' => 'host',
     ) }
 
     it { should contain_nagios__resource('templateservice').with(
-      'type' => 'service',
+      'resource_type' => 'service',
     ) }
 
     it { should contain_nagios__resource('templatetimeperiod').with(
-      'type' => 'timeperiod',
+      'resource_type' => 'timeperiod',
     ) }
   end
 

--- a/spec/defines/resource_spec.rb
+++ b/spec/defines/resource_spec.rb
@@ -27,7 +27,7 @@ describe 'nagios::resource', :type => :define do
   context 'with good params' do
     let(:params) {
       {
-        'type'           => 'command',
+        'resource_type' => 'command',
         'nagiostag'   => 'nagios-foo',
       }
     }
@@ -35,7 +35,7 @@ describe 'nagios::resource', :type => :define do
     it { should compile }
 
     it 'should fail on bad type' do
-      params.merge!({'type' => 'badvalue'})
+      params.merge!({'resource_type' => 'badvalue'})
       expect { should compile }.to \
         raise_error(RSpec::Expectations::ExpectationNotMetError,
           /Unknown resource type passed of 'badvalue'/)
@@ -55,68 +55,68 @@ describe 'nagios::resource', :type => :define do
       )
     end
 
-    it 'should have contact define when type => contact' do
-      params.merge!({ 'type' => 'contact' })
+    it 'should have contact define when resource_type => contact' do
+      params.merge!({ 'resource_type' => 'contact' })
       should contain_nagios__resource__contact('Test me')
     end
 
-    it 'should have contactgroup define when type => contactgroup' do
-      params.merge!({ 'type' => 'contactgroup' })
+    it 'should have contactgroup define when resource_type => contactgroup' do
+      params.merge!({ 'resource_type' => 'contactgroup' })
       should contain_nagios__resource__contactgroup('Test me')
     end
 
     it 'should have host define when type => host' do
-      params.merge!({ 'type' => 'host' })
+      params.merge!({ 'resource_type' => 'host' })
       should contain_nagios__resource__host('Test me')
     end
 
-    it 'should have hostdependency define when type => hostdependency' do
-      params.merge!({ 'type' => 'hostdependency' })
+    it 'should have hostdependency define when resource_type => hostdependency' do
+      params.merge!({ 'resource_type' => 'hostdependency' })
       should contain_nagios__resource__hostdependency('Test me')
     end
 
-    it 'should have hostescalation define when type => hostescalation' do
-      params.merge!({ 'type' => 'hostescalation' })
+    it 'should have hostescalation define when resource_type => hostescalation' do
+      params.merge!({ 'resource_type' => 'hostescalation' })
       should contain_nagios__resource__hostescalation('Test me')
     end
 
-    it 'should have hostextinfo define when type => hostextinfo' do
-      params.merge!({ 'type' => 'hostextinfo'})
+    it 'should have hostextinfo define when resource_type => hostextinfo' do
+      params.merge!({ 'resource_type' => 'hostextinfo'})
       should contain_nagios__resource__hostextinfo('Test me')
     end
 
-    it 'should have hostgroup define when type => hostgroup' do
-      params.merge!({ 'type' => 'hostgroup'})
+    it 'should have hostgroup define when resource_type => hostgroup' do
+      params.merge!({ 'resource_type' => 'hostgroup'})
       should contain_nagios__resource__hostgroup('Test me')
     end
 
-    it 'should have service define when type => service' do
-      params.merge!({ 'type' => 'service'})
+    it 'should have service define when resource_type => service' do
+      params.merge!({ 'resource_type' => 'service'})
       should contain_nagios__resource__service('Test me')
     end
 
-    it 'should have servicedependency define when type => servicedependency' do
-      params.merge!({ 'type' => 'servicedependency'})
+    it 'should have servicedependency define when resource_type => servicedependency' do
+      params.merge!({ 'resource_type' => 'servicedependency'})
       should contain_nagios__resource__servicedependency('Test me')
     end
 
-    it 'should have serviceescalation define when type => serviceescalation' do
-      params.merge!({ 'type' => 'serviceescalation'})
+    it 'should have serviceescalation define when resource_type => serviceescalation' do
+      params.merge!({ 'resource_type' => 'serviceescalation'})
       should contain_nagios__resource__serviceescalation('Test me')
     end
 
-    it 'should have serviceextinfo define when type => serviceextinfo' do
-      params.merge!({ 'type' => 'serviceextinfo'})
+    it 'should have serviceextinfo define when resource_type => serviceextinfo' do
+      params.merge!({ 'resource_type' => 'serviceextinfo'})
       should contain_nagios__resource__serviceextinfo('Test me')
     end
 
-    it 'should have servicegroup define when type => servicegroup' do
-      params.merge!({ 'type' => 'servicegroup'})
+    it 'should have servicegroup define when resource_type => servicegroup' do
+      params.merge!({ 'resource_type' => 'servicegroup'})
       should contain_nagios__resource__servicegroup('Test me')
     end
 
-    it 'should have timeperiod define when type => timeperiod' do
-      params.merge!({ 'type' => 'timeperiod'})
+    it 'should have timeperiod define when resource_type => timeperiod' do
+      params.merge!({ 'resource_type' => 'timeperiod'})
       should contain_nagios__resource__timeperiod('Test me')
     end
 


### PR DESCRIPTION
This is due to the fact that 'type' keyword is reserved for future needs: https://docs.puppetlabs.com/puppet/latest/reference/lang_reserved.html

Signed-off-by: Anton Baranov <abaranov@linuxfoundation.org>