### PR TITLE
Remove service provider: RedHat

### DIFF
--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -26,7 +26,6 @@ class nagios::server::service {
     ensure     => running,
     enable     => true,
     hasrestart => true,
-    provider   => 'redhat',
     # lint:ignore:80chars
     restart    => "${nagios::params::basename} -v ${nagios::params::conffile} && service nagios reload",
     # lint:endignore


### PR DESCRIPTION
Puppet 4.0.8 in EPEL now uses systemd and specifying redhat prevents it from becoming enabled.