### PR TITLE
Make the file resource collection notify nagios service

### DIFF
--- a/manifests/server/config/import.pp
+++ b/manifests/server/config/import.pp
@@ -37,5 +37,7 @@ class nagios::server::config::import (
   # specific File resources are exported for each of the nagios_*
   # resources to get around issues with how file targets don't make the
   # files managed from the point of view of purge.
-  File <<| tag == $nagiostag |>> { }
+  File <<| tag == $nagiostag |>> {
+    notify => Class[ 'nagios::server::service' ]
+  }
 }


### PR DESCRIPTION
Currently exported resources are not being picked up by
the nagios server because adding new resources does not
notify the service and cause the daemon to restart and
pick up the new hosts/services.

Signed-off-by: Jordan Conway jconway@linuxfoundation.org
